### PR TITLE
feat: add pihole service to docker-compose

### DIFF
--- a/applications/docker-compose-apps/docker-compose.yaml
+++ b/applications/docker-compose-apps/docker-compose.yaml
@@ -53,6 +53,21 @@ services:
     environment:
       PAPERLESS_REDIS: redis://broker:6379
 
+  pihole:
+    image: pihole/pihole:latest
+    container_name: pihole
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "82:80/tcp"
+    environment:
+      TZ: 'America/Toronto'
+      WEBPASSWORD: 'changeme'
+    volumes:
+      - '/opt/pihole/etc-pihole:/etc/pihole'
+      - '/opt/pihole/etc-dnsmasq.d:/etc/dnsmasq.d'
+    restart: unless-stopped
+
 volumes:
   datadir:
     external: true


### PR DESCRIPTION
This commit adds the Pi-hole service to the docker-compose.yaml file, as requested in issue #29. This will provide network-wide ad blocking.